### PR TITLE
カスタム権限ありの場合の修正。

### DIFF
--- a/spec/lib/acl-conditions.coffee
+++ b/spec/lib/acl-conditions.coffee
@@ -1,0 +1,52 @@
+
+AclConditions = require '../../src/lib/acl-conditions'
+
+describe 'AclConditions', ->
+
+    describe 'hasCustomWrite', ->
+
+        it '「my-customのrw」はカスタム権限の編集許可を持っている', ->
+
+            aclType =
+                'owner': 'rwx'
+                'my-custom': 'rw'
+
+            aclConditions = new AclConditions(aclType)
+            assert aclConditions.hasCustomWrite() is true
+
+        it '「my-customのr」はカスタム権限の編集許可を持っていない', ->
+
+            aclType =
+                'owner': 'rwx'
+                'my-custom': 'r'
+
+            aclConditions = new AclConditions(aclType)
+            assert aclConditions.hasCustomWrite() is false
+
+        it '「owner」はカスタム権限の編集許可を持っていない', ->
+
+            aclType = 'owner'
+
+            aclConditions = new AclConditions(aclType)
+            assert aclConditions.hasCustomWrite() is false
+
+        it '「public」はカスタム権限の編集許可を持っていない', ->
+
+            aclType = 'public'
+
+            aclConditions = new AclConditions(aclType)
+            assert aclConditions.hasCustomWrite() is false
+
+        it '「admin」はカスタム権限の編集許可を持っていない', ->
+
+            aclType = 'admin'
+
+            aclConditions = new AclConditions(aclType)
+            assert aclConditions.hasCustomWrite() is false
+
+        it '「member」はカスタム権限の編集許可を持っていない', ->
+
+            aclType = 'member'
+
+            aclConditions = new AclConditions(aclType)
+            assert aclConditions.hasCustomWrite() is false

--- a/src/lib/acl-conditions.coffee
+++ b/src/lib/acl-conditions.coffee
@@ -57,5 +57,12 @@ class AclConditions
             return false if regularPermissions.length > 0
         return true
 
+    hasCustomWrite: ->
+        for name, permissions of @customPermissions
+            if isNaN(parseInt(name)) is false
+                continue
+            if permissions.indexOf('WRITE') isnt -1
+                return true
+        false
 
 module.exports = AclConditions

--- a/src/lib/acl-generator.coffee
+++ b/src/lib/acl-generator.coffee
@@ -132,14 +132,15 @@ class AclGenerator
             permission: 'DENY'
             property: 'logout'
 
-        # user creation is denied by default.
-        @acl.push
-            accessType: 'WRITE'
-            principalType: 'ROLE'
-            principalId: '$everyone'
-            permission: 'DENY'
-            property: 'create'
-        @
+        if @aclConditions.hasCustomWrite() is false
+            # user creation is denied by default.
+            @acl.push
+                accessType: 'WRITE'
+                principalType: 'ROLE'
+                principalId: '$everyone'
+                permission: 'DENY'
+                property: 'create'
+            @
 
         # user creation is allowed by admin.
         @acl.push


### PR DESCRIPTION
カスタム権限をWRITEを有効にしてもcreateできない。
カスタム権限でWRITEしてありの場合は$everyone,createがDENYをjsonに記述しない修正。