### PR TITLE
カスタム権限のWRITEでcreate許可。

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "gulp-plumber": "^1.1.0",
     "gulp-yuidoc": "^0.1.2",
     "mocha": "^2.4.5",
-    "node-circleci-autorelease": "^1.6.1",
+    "node-circleci-autorelease": "^2.1.8",
     "power-assert": "^1.3.1"
   },
   "repository": {

--- a/spec/lib/acl-generator.coffee
+++ b/spec/lib/acl-generator.coffee
@@ -321,5 +321,23 @@ describe 'AclGenerator', ->
 
                 assert acl.length is 8
 
+        describe 'when aclType is custom",', ->
 
+            it 'カスタム権限のプロパティはcreate, updateAttributes用の2つが生成される', ->
 
+                aclType =
+                    'my-custom': 'rw'
+                isUser = true
+                acl = new AclGenerator(aclType, isUser).generate()
+
+                assert acl[6].principalType is 'ROLE'
+                assert acl[6].principalId is 'my-custom'
+                assert acl[6].permission is 'ALLOW'
+                assert acl[6].accessType is 'WRITE'
+                assert acl[6].property is 'create'
+
+                assert acl[7].principalType is 'ROLE'
+                assert acl[7].principalId is 'my-custom'
+                assert acl[7].permission is 'ALLOW'
+                assert acl[7].accessType is 'WRITE'
+                assert acl[7].property is 'updateAttributes'

--- a/src/lib/acl-generator.coffee
+++ b/src/lib/acl-generator.coffee
@@ -72,7 +72,7 @@ class AclGenerator
         @addAllowACL('$owner',         @aclConditions.basicPermissions.owner)
 
         for roleName, accessTypes of @aclConditions.customPermissions
-            @addAllowACL(roleName, accessTypes)
+            @addAllowACL(roleName, accessTypes, ['create', 'updateAttributes'])
 
         return @acl
 
@@ -83,15 +83,23 @@ class AclGenerator
     @method ownerACL
     @private
     ###
-    addAllowACL: (principalId, accessTypes) ->
+    addAllowACL: (principalId, accessTypes, properties = []) ->
 
         accessTypes.forEach (accessType) =>
-            @acl.push
-                accessType: accessType
-                principalType: 'ROLE'
-                principalId: principalId
-                permission: 'ALLOW'
-
+            if properties.length > 0 and accessType is 'WRITE'
+                for property in properties
+                    @acl.push
+                        accessType: accessType
+                        principalType: 'ROLE'
+                        principalId: principalId
+                        permission: 'ALLOW'
+                        property: property
+            else
+                @acl.push
+                    accessType: accessType
+                    principalType: 'ROLE'
+                    principalId: principalId
+                    permission: 'ALLOW'
 
     ###*
     append basic ACL, which allow accesses only from admin


### PR DESCRIPTION
カスタム権限の出力時の設定を細かく指定するように修正。
create禁止($everyone,WRITE,create,DENY)がカスタム編集許可(coustm,WRITE,ALLOW)より強く効かないのでカスタム編集create許可(custom,WRITE,create,ALLOW)を出力するように修正。