### PR TITLE
Add property setting of custom permissions

### DIFF
--- a/spec/lib/acl-generator.coffee
+++ b/spec/lib/acl-generator.coffee
@@ -321,5 +321,25 @@ describe 'AclGenerator', ->
 
                 assert acl.length is 8
 
+        describe 'when aclType is "custom" and give permission to write', ->
+
+            it 'appends AC allowing create and updateAttributes', ->
+
+                aclType =
+                    'my-custom': 'rw'
+                isUser = true
+                acl = new AclGenerator(aclType, isUser).generate()
+
+                assert acl[6].principalType is 'ROLE'
+                assert acl[6].principalId is 'my-custom'
+                assert acl[6].permission is 'ALLOW'
+                assert acl[6].accessType is 'WRITE'
+                assert acl[6].property is 'create'
+
+                assert acl[7].principalType is 'ROLE'
+                assert acl[7].principalId is 'my-custom'
+                assert acl[7].permission is 'ALLOW'
+                assert acl[7].accessType is 'WRITE'
+                assert acl[7].property is 'updateAttributes'
 
 

--- a/src/lib/acl-generator.coffee
+++ b/src/lib/acl-generator.coffee
@@ -72,7 +72,7 @@ class AclGenerator
         @addAllowACL('$owner',         @aclConditions.basicPermissions.owner)
 
         for roleName, accessTypes of @aclConditions.customPermissions
-            @addAllowACL(roleName, accessTypes)
+            @addAllowACL(roleName, accessTypes, ['create', 'updateAttributes'])
 
         return @acl
 
@@ -83,14 +83,24 @@ class AclGenerator
     @method ownerACL
     @private
     ###
-    addAllowACL: (principalId, accessTypes) ->
+    addAllowACL: (principalId, accessTypes, properties = []) ->
 
         accessTypes.forEach (accessType) =>
-            @acl.push
-                accessType: accessType
-                principalType: 'ROLE'
-                principalId: principalId
-                permission: 'ALLOW'
+            if properties.length > 0 and accessType is 'WRITE'
+                for property in properties
+                    @acl.push
+                        accessType: accessType
+                        principalType: 'ROLE'
+                        principalId: principalId
+                        permission: 'ALLOW'
+                        property: property
+            else
+                @acl.push
+                    accessType: accessType
+                    principalType: 'ROLE'
+                    principalId: principalId
+                    permission: 'ALLOW'
+
 
 
     ###*


### PR DESCRIPTION
- Output the create and updateAttributes WRITE permission for the custom.

```
 // model.json
    {
      "accessType": "WRITE",
      "principalType": "ROLE",
      "principalId": "custom1",
      "permission": "ALLOW",
      "property": "create"
    },
    {
      "accessType": "WRITE",
      "principalType": "ROLE",
      "principalId": "custom1",
      "permission": "ALLOW",
      "property": "updateAttributes"
    }
```