### PR TITLE
Add relation acl

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "2.2.0",
   "main": "dist/main.js",
   "scripts": {
-    "test": "mocha -r spec/global.js spec/main.coffee spec/lib/*.coffee"
+    "test": "mocha -r spec/global.js spec/main.coffee spec/lib/*.coffee",
+    "single": "mocha -r spec/global.js"
   },
   "author": "CureApp, Inc.",
   "license": "MIT",

--- a/spec/lib/models-generator.coffee
+++ b/spec/lib/models-generator.coffee
@@ -229,6 +229,86 @@ describe 'ModelsGenerator', ->
 
                 done()
 
+    describe 'generate, when give the relation define, and owner permission is undefined', ->
+
+        before ->
+
+            # job aclType = ''
+            define =
+                staff:
+                    aclType:
+                        owner: 'rwx'
+                    name: 'staff'
+                    plural: 'staff'
+                    base: 'User'
+                    idInjection: true
+                    properties: {}
+                    validations: []
+                    relations:
+                        'job-with-staffId':
+                            type: 'hasMany', model: 'staff', foreignKey: 'staffId'
+                        job:
+                            type: 'hasMany', model: 'staff', foreignKey: 'staffId'
+                job:
+                    aclType: ''
+                    name: 'job',
+                    plural: 'job',
+                    base: 'PersistedModel',
+                    idInjection: true,
+                    properties: {},
+                    validations: [],
+                    relations:
+                        staff:
+                            type: 'belongsTo', model: 'staff', foreignKey: 'staffId'
+
+
+            @generator = new ModelsGenerator(define)
+            @generator.destinationDir = __dirname + '/d'
+            @generator.modelConfigGenerator.destinationPath = __dirname + '/d'
+            fs.mkdirsSync __dirname + '/d'
+
+        after ->
+            fs.removeSync __dirname + '/d'
+
+        it 'generate JSON file include related models', (done) ->
+
+            @generator.generate()
+
+            fs.readFile __dirname + '/d/staff.json', 'utf8', (err, data) ->
+
+                acls = JSON.parse(data).acls
+
+                acl = [
+                    accessType      : "WRITE"
+                    permission      : "DENY"
+                    principalId     : "$owner"
+                    principalType   : "ROLE"
+                    property        : "__create__job"
+                ,
+                    accessType      : "WRITE"
+                    permission      : "DENY"
+                    principalId     : "$owner"
+                    principalType   : "ROLE"
+                    property        : "__delete__job"
+                ,
+                    accessType      : "WRITE"
+                    permission      : "DENY"
+                    principalId     : "$owner"
+                    principalType   : "ROLE"
+                    property        : "__destroyById__job"
+                ,
+                    accessType      : "WRITE"
+                    permission      : "DENY"
+                    principalId     : "$owner"
+                    principalType   : "ROLE"
+                    property        : "__updateById__job"
+                ]
+
+                assert.deepEqual acls.splice(8, 4), acl
+
+                done()
+
+
     describe 'generate, when give the relation define, and owner permission is read-write', ->
 
         before ->

--- a/spec/lib/models-generator.coffee
+++ b/spec/lib/models-generator.coffee
@@ -148,5 +148,81 @@ describe 'ModelsGenerator', ->
             assert generated.names.length is 4
             assert typeof generated.config is 'object'
 
+    describe 'generate, give the relation define', ->
+
+        before ->
+
+            define =
+                staff:
+                    aclType:
+                        owner: 'rwx'
+                    name: 'staff'
+                    plural: 'staff'
+                    base: 'User'
+                    idInjection: true
+                    properties: {}
+                    validations: []
+                    relations:
+                        'job-with-staffId':
+                            type: 'hasMany', model: 'staff', foreignKey: 'staffId'
+                        job:
+                            type: 'hasMany', model: 'staff', foreignKey: 'staffId'
+                job:
+                    aclType:
+                        owner: 'r'
+                    name: 'job',
+                    plural: 'job',
+                    base: 'PersistedModel',
+                    idInjection: true,
+                    properties: {},
+                    validations: [],
+                    relations:
+                        staff:
+                            type: 'belongsTo', model: 'staff', foreignKey: 'staffId'
 
 
+            @generator = new ModelsGenerator(define)
+            @generator.destinationDir = __dirname + '/d'
+            @generator.modelConfigGenerator.destinationPath = __dirname + '/d'
+            fs.mkdirsSync __dirname + '/d'
+
+        after ->
+            fs.removeSync __dirname + '/d'
+
+        it 'generate JSON file include related models', (done) ->
+
+            @generator.generate()
+
+            fs.readFile __dirname + '/d/staff.json', 'utf8', (err, data) ->
+
+                acls = JSON.parse(data).acls
+
+                acl = [
+                    accessType      : "WRITE"
+                    permission      : "DENY"
+                    principalId     : "$owner"
+                    principalType   : "ROLE"
+                    property        : "__create__job"
+                ,
+                    accessType      : "WRITE"
+                    permission      : "DENY"
+                    principalId     : "$owner"
+                    principalType   : "ROLE"
+                    property        : "__delete__job"
+                ,
+                    accessType      : "WRITE"
+                    permission      : "DENY"
+                    principalId     : "$owner"
+                    principalType   : "ROLE"
+                    property        : "__destroyById__job"
+                ,
+                    accessType      : "WRITE"
+                    permission      : "DENY"
+                    principalId     : "$owner"
+                    principalType   : "ROLE"
+                    property        : "__updateById__job"
+                ]
+
+                assert.deepEqual acls.splice(8, 4), acl
+
+                done()

--- a/spec/lib/models-generator.coffee
+++ b/spec/lib/models-generator.coffee
@@ -148,9 +148,11 @@ describe 'ModelsGenerator', ->
             assert generated.names.length is 4
             assert typeof generated.config is 'object'
 
-    describe 'generate, give the relation define', ->
+    describe 'generate, when give the relation define, and owner permission is read only', ->
 
         before ->
+
+            ownerPermission = 'r'
 
             define =
                 staff:
@@ -169,7 +171,7 @@ describe 'ModelsGenerator', ->
                             type: 'hasMany', model: 'staff', foreignKey: 'staffId'
                 job:
                     aclType:
-                        owner: 'r'
+                        owner: ownerPermission
                     name: 'job',
                     plural: 'job',
                     base: 'PersistedModel',
@@ -222,6 +224,63 @@ describe 'ModelsGenerator', ->
                     principalType   : "ROLE"
                     property        : "__updateById__job"
                 ]
+
+                assert.deepEqual acls.splice(8, 4), acl
+
+                done()
+
+    describe 'generate, when give the relation define, and owner permission is read-write', ->
+
+        before ->
+
+            ownerPermission = 'rw'
+
+            define =
+                staff:
+                    aclType:
+                        owner: 'rwx'
+                    name: 'staff'
+                    plural: 'staff'
+                    base: 'User'
+                    idInjection: true
+                    properties: {}
+                    validations: []
+                    relations:
+                        'job-with-staffId':
+                            type: 'hasMany', model: 'staff', foreignKey: 'staffId'
+                        job:
+                            type: 'hasMany', model: 'staff', foreignKey: 'staffId'
+                job:
+                    aclType:
+                        owner: ownerPermission
+                    name: 'job',
+                    plural: 'job',
+                    base: 'PersistedModel',
+                    idInjection: true,
+                    properties: {},
+                    validations: [],
+                    relations:
+                        staff:
+                            type: 'belongsTo', model: 'staff', foreignKey: 'staffId'
+
+
+            @generator = new ModelsGenerator(define)
+            @generator.destinationDir = __dirname + '/d'
+            @generator.modelConfigGenerator.destinationPath = __dirname + '/d'
+            fs.mkdirsSync __dirname + '/d'
+
+        after ->
+            fs.removeSync __dirname + '/d'
+
+        it 'generate JSON file does not include related models', (done) ->
+
+            @generator.generate()
+
+            fs.readFile __dirname + '/d/staff.json', 'utf8', (err, data) ->
+
+                acls = JSON.parse(data).acls
+
+                acl = []
 
                 assert.deepEqual acls.splice(8, 4), acl
 

--- a/src/lib/acl-generator.coffee
+++ b/src/lib/acl-generator.coffee
@@ -73,8 +73,12 @@ class AclGenerator
 
         # deny write of related model if read only permission
         for roleName, relationDefine of @relationDefinitions
-            rwx = relationDefine.aclType.owner
-            accessTypes = AclConditions.regularPermissions(rwx)
+            if relationDefine.aclType.owner?
+                rwx = relationDefine.aclType.owner
+                accessTypes = AclConditions.regularPermissions(rwx)
+            else
+                accessTypes = ['READ']
+
             if accessTypes.length is 1 and accessTypes[0] is 'READ'
                 @addDenyACL('$owner', ['WRITE'], @getRestrictingProperties(relationDefine.type, 'WRITE', roleName))
 

--- a/src/lib/model-definition.coffee
+++ b/src/lib/model-definition.coffee
@@ -7,7 +7,7 @@ AclGenerator = require './acl-generator'
 ###
 class ModelDefinition
 
-    constructor: (@modelName, @customDefinition = {}) ->
+    constructor: (@modelName, @customDefinition = {}, @relationDefinitions = {}) ->
 
         @definition = @getDefaultDefinition()
         @definition[k] = @customDefinition[k] for k, v of @customDefinition
@@ -71,7 +71,7 @@ class ModelDefinition
             return
 
         @aclType ?= 'admin'
-        @definition.acls = new AclGenerator(@aclType, @isUser()).generate()
+        @definition.acls = new AclGenerator(@aclType, @isUser(), @relationDefinitions).generate()
 
 
     ###*

--- a/src/lib/models-generator.coffee
+++ b/src/lib/models-generator.coffee
@@ -120,6 +120,26 @@ class ModelsGenerator
     getEmptyJSContent: ->
         'module.exports = function(Model) {};'
 
+    ###*
+    get RelationDefinition
+
+    @private
+    ###
+    getRelationDefinitions: (customModelDefinition, customModelDefinitions) ->
+
+        definitions = {}
+
+        for relationName, relationDefinition of customModelDefinition.relations
+
+            continue unless customModelDefinitions[relationName]
+
+            switch relationDefinition.type
+                when 'hasMany'
+                    definitions[relationName] =
+                        type: relationDefinition.type
+                        aclType: customModelDefinitions[relationName].aclType
+
+        return definitions
 
     ###*
     create ModelDefinition instances
@@ -132,7 +152,10 @@ class ModelsGenerator
 
         for modelName, customModelDefinition of customModelDefinitions
 
-            definitions[modelName] = new ModelDefinition(modelName, customModelDefinition)
+            if customModelDefinition.relations?
+                relationDefinitions = @getRelationDefinitions(customModelDefinition, customModelDefinitions)
+
+            definitions[modelName] = new ModelDefinition(modelName, customModelDefinition, relationDefinitions)
 
         return definitions
 


### PR DESCRIPTION
- A belong to B, And owner permission of A is read only then, B.json includes DENY-WRITE

``` js
// B.json acls
  ...
  { accessType: 'WRITE',
    principalType: 'ROLE',
    principalId: '$owner',
    permission: 'DENY',
    property: '__create__a' },
  { accessType: 'WRITE',
    principalType: 'ROLE',
    principalId: '$owner',
    permission: 'DENY',
    property: '__delete__a' },
  { accessType: 'WRITE',
    principalType: 'ROLE',
    principalId: '$owner',
    permission: 'DENY',
    property: '__destroyById__a' },
  { accessType: 'WRITE',
    principalType: 'ROLE',
    principalId: '$owner',
    permission: 'DENY',
    property: '__updateById__a' }
```