### PR TITLE
npm run buildを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "dist/main.js",
   "scripts": {
     "test": "mocha -r spec/global.js spec/main.coffee spec/lib/*.coffee",
-    "single": "mocha -r spec/global.js"
+    "single": "mocha -r spec/global.js",
+    "build": "gulp coffee"
   },
   "author": "CureApp, Inc.",
   "license": "MIT",


### PR DESCRIPTION
- [cureapp way](https://cureapp.docbase.io/posts/86161)準拠
- `gulp-cli`のグローバルインストール不要にする