### PR TITLE
Prioritize  user specified value

### DIFF
--- a/loopback/server/server.js
+++ b/loopback/server/server.js
@@ -1,31 +1,41 @@
 var loopback = require('loopback');
 var boot = require('loopback-boot');
 
-var app = module.exports = loopback();
+module.exports = function(config) {
+  var app = loopback();
 
-app.start = function(callback) {
-  boot(app, __dirname, function(err) {
-    if (err) return callback(err)
+  app.start = function(callback) {
+    boot(app, __dirname, function(err) {
+      if (err) return callback(err)
 
-      // start the web server
-      app.listen(function(err) {
+        // set port, host
+        if(config && Object.keys(config).length !== 0) {
+          Object.keys(config).forEach(function(key) {
+            app.set(key, config[key]);
+          })
+        }
 
-        if (err) return callback(err)
+        // start the web server
+        app.listen(function(err) {
 
-        app.emit('started');
-        console.log('Web server listening at: %s', app.get('url'));
+          if (err) return callback(err)
 
-        console.log('LOOPBACK_WITH_ADMIN_STARTED');
+          app.emit('started');
+          console.log('Web server listening at: %s', app.get('url'));
 
-        callback()
-      });
-  });
-};
+          console.log('LOOPBACK_WITH_ADMIN_STARTED');
 
-// Bootstrap the application, configure models, datasources and middleware.
-// Sub-apps like REST API are mounted via boot scripts.
+          callback()
+        });
+    });
+  };
 
-// start the server if `$ node server.js`
-if (require.main === module) {
-  app.start();
+  // Bootstrap the application, configure models, datasources and middleware.
+  // Sub-apps like REST API are mounted via boot scripts.
+
+  // start the server if `$ node server.js`
+  if (require.main === module) {
+    app.start();
+  }
+  return app;
 }

--- a/spec/lib/loopback-server.coffee
+++ b/spec/lib/loopback-server.coffee
@@ -1,5 +1,7 @@
 
 { normalize } = require 'path'
+{ get } = require 'http'
+assert = require 'power-assert'
 
 LoopbackServer = require '../../src/lib/loopback-server'
 Main = require '../../src/main'
@@ -9,7 +11,7 @@ config = server: port: 3001
 describe 'LoopbackServer', ->
 
     before ->
-        @main = new Main({}, config)
+        @main = new Main({}, {})
         @main.reset()
         @main.generate()
 
@@ -19,8 +21,27 @@ describe 'LoopbackServer', ->
 
     describe 'launch', ->
 
-        it 'runs loopback in the same process', ->
+        it 'runs loopback at localhost:3000, if call launch() without argument', ->
+            @timeout 30000
+
+            launcher = new LoopbackServer()
+            launcher.launch()
+            .then () ->
+                get 'http://localhost:3000', (res) ->　assert res.status is 200
+
+        it 'runs loopback at localhost:3001, if argument is passed to launch()', ->
             @timeout 30000
 
             launcher = new LoopbackServer()
             launcher.launch(config.server)
+            .then () ->
+                get 'http://localhost:3001', (res) ->　assert res.status is 200
+
+        it 'runs loopback at localhost:4444, if there is no argument but PORT is set', ->
+            @timeout 30000
+
+            process.env.PORT = 4444
+            launcher = new LoopbackServer()
+            launcher.launch()
+            .then () ->
+                get 'http://localhost:4444', (res) ->　assert res.status is 200

--- a/spec/lib/loopback-server.coffee
+++ b/spec/lib/loopback-server.coffee
@@ -4,11 +4,12 @@
 LoopbackServer = require '../../src/lib/loopback-server'
 Main = require '../../src/main'
 
+config = server: port: 3001
 
 describe 'LoopbackServer', ->
 
     before ->
-        @main = new Main({}, server: port: 3001)
+        @main = new Main({}, config)
         @main.reset()
         @main.generate()
 
@@ -22,4 +23,4 @@ describe 'LoopbackServer', ->
             @timeout 30000
 
             launcher = new LoopbackServer()
-            launcher.launch()
+            launcher.launch(config.server)

--- a/spec/main.coffee
+++ b/spec/main.coffee
@@ -138,7 +138,7 @@ describe 'Main', ->
 
             params = null
 
-            Main.launchLoopback = (p) =>
+            Main.launchLoopback = (_, p, __) =>
                 params = p
                 Promise.resolve @called.launchLoopback = true
 

--- a/src/lib/loopback-server.coffee
+++ b/src/lib/loopback-server.coffee
@@ -23,7 +23,7 @@ class LoopbackServer
     ###
     launch: (options = {}, participantToken) -> new Promise (resolve, reject) =>
 
-        @app = require(@entryPath)
+        @app = require(@entryPath)(options)
 
         # see loopback/server/boot/admin.js
         @app.lwaTokenManager = new AdminTokenManager(options)

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -48,7 +48,7 @@ class Main
 
         adminOptions = options.admin or options.adminToken # adminToken is for backward compatibility
 
-        @launchLoopback(adminOptions, options.participantToken).then (server) =>
+        @launchLoopback(generated.config, adminOptions, options.participantToken).then (server) =>
             return new LoopbackInfo(server, generated)
 
 
@@ -99,11 +99,11 @@ class Main
     ###*
     run loopback
 
+    @param {Object} [serverConfig] defaut config is defined in : default-values/non-model-configs/server.json
     @private
     ###
-    @launchLoopback: (adminOptions, participantToken) ->
-
+    @launchLoopback: (serverConfig, adminOptions, participantToken) ->
         server = new LoopbackServer()
-        server.launch(adminOptions, participantToken).then => server
+        server.launch(serverConfig.server, adminOptions, participantToken).then => server
 
 module.exports = Main


### PR DESCRIPTION
In local development,  user-specified port value is always disregarded, **if `PORT` is set**



```bash
$(npm bin)/mocha -r spec/global.js spec/lib/loopback-server.coffee
```
results:
```bash
Browse your REST API at http://localhost:3001/explorer
Web server listening at: http://localhost:3001/
```

but if `PORT` is set, printed like below:

```bash
PORT=4444 $(npm bin)/mocha -r spec/global.js spec/lib/loopback-server.coffee
```

```bash
  LoopbackServer
    launch
Browse your REST API at http://localhost:4444/explorer
Web server listening at: http://localhost:4444/
LOOPBACK_WITH_ADMIN_STARTED
Admin token will be refreshed every 12 hours.
      ✓ runs loopback in the same process (1490ms)

  1 passing (2s)
```

This PR changes prioritize  order

1. user specified value
2. value of `PORT`
3. `3000`( default value of this package)

